### PR TITLE
Fix PWA manifest generation and theme preference

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -49,14 +49,10 @@ function App() {
     }, []);
 
     useEffect(() => {
-        const isDarkTheme = localStorage.getItem('isDarkTheme') === 'true';
-        const theme = isDarkTheme ? 'dark' : 'light';
+        const savedPreference = localStorage.getItem('isDarkTheme') === 'true';
+        const theme = savedPreference ? 'dark' : 'light';
         document.documentElement.setAttribute('data-theme', theme);
-        dispatch(setTheme(isDarkTheme))
-    }, [])
-
-    useEffect(() => {
-        dispatch(setTheme(true));
+        dispatch(setTheme(savedPreference));
     }, [])
 
     return (

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -21,24 +21,26 @@ export default defineConfig({
             threshold: 1024,
         }),
         VitePWA({
-            "short_name": "My Lenses, by Andrei Pascu",
-            "name": "Andrei Pascu's online web gallery.",
-            "icons": [
-                {
-                    "src": "favicon.ico",
-                    "sizes": "64x64 32x32 24x24 16x16",
-                    "type": "image/x-icon"
-                },
-                {
-                    "src": "logo192.png",
-                    "type": "image/png",
-                    "sizes": "16x16"
-                }
-            ],
-            "start_url": ".",
-            "display": "standalone",
-            "theme_color": "#000000",
-            "background_color": "#ffffff"
+            manifest: {
+                short_name: 'My Lenses, by Andrei Pascu',
+                name: "Andrei Pascu's online web gallery.",
+                icons: [
+                    {
+                        src: 'favicon.ico',
+                        sizes: '64x64 32x32 24x24 16x16',
+                        type: 'image/x-icon'
+                    },
+                    {
+                        src: 'logo192.png',
+                        type: 'image/png',
+                        sizes: '16x16'
+                    }
+                ],
+                start_url: '.',
+                display: 'standalone',
+                theme_color: '#000000',
+                background_color: '#ffffff'
+            }
         }),
     ],
     server: {


### PR DESCRIPTION
## Summary
- generate complete `manifest.webmanifest` by nesting options under `manifest` when using VitePWA
- respect stored theme preference when initializing the app

## Testing
- `npm test` *(fails: No test files found)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68469f21ade4832b8e09d5434f6e7a9d