### PR TITLE
Optimize image imports for performance

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,6 +34,7 @@
     <!-- Preload Google Fonts for better performance -->
     <link href="https://fonts.googleapis.com" rel="preconnect">
     <link crossorigin href="https://fonts.gstatic.com" rel="preconnect">
+    <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Nunito:ital,wght@0,200..1000;1,200..1000&display=swap">
     <link href="https://fonts.googleapis.com/css2?family=Nunito:ital,wght@0,200..1000;1,200..1000&display=swap"
           rel="stylesheet">
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,9 +16,9 @@ function App() {
 
 
     useEffect(() => {
-        Promise.all(images)
+        Promise.all(images.map((load) => load()))
             .then((imgs) => {
-                const images = imgs.map((img: any) => {
+                const loaded = imgs.map((img: any) => {
                     return {
                         src: img.default,
                         //extract the title from the image source
@@ -26,23 +26,23 @@ function App() {
                     }
                 });
 
-                dispatch(setPhotos(images));
+                dispatch(setPhotos(loaded));
             })
             .catch((error) => console.error('Error loading images', error))
             .finally(() => console.log('Images loaded'));
     }, []);
 
     useEffect(() => {
-        Promise.all(canvaseImages)
+        Promise.all(canvaseImages.map((load) => load()))
             .then((imgs) => {
-                const images = imgs.map((img: any) => {
+                const imagesLoaded = imgs.map((img: any) => {
                     return {
                         src: img.default,
                         //extract the title from the image source
                         title: img.default.split('/').pop()?.split('.')[0],
                     }
                 });
-                dispatch(setCanvasPhotos(images));
+                dispatch(setCanvasPhotos(imagesLoaded));
             })
             .catch((error) => console.error('Error loading images', error))
             .finally(() => console.log('Canvas Images loaded'));

--- a/src/components/main-page/PhotoGallery.tsx
+++ b/src/components/main-page/PhotoGallery.tsx
@@ -1,6 +1,5 @@
 import React, {useEffect, useState} from 'react';
 import SelectedPhoto from './SelectedPhoto';
-import InitialImage from '../../assets/photos/Stelvio pass v2.jpg';
 import {useSelector} from "react-redux";
 import {RootState} from "../../store/store";
 
@@ -13,7 +12,7 @@ const PhotoGallery = ({images, imageDescriptions}: PhotoGalleryProps) => {
     const [selectedImage, setSelectedImage] = useState<any | null>(null);
     const [selectedImageDescription, setSelectedImageDescription] = useState<any | null>(null);
     const [selectedImageTitle, setSelectedImageTitle] = useState<any | null>(null);
-    const [previouseSelectedImage, setPreviousSelectedImage] = useState<any | null>(InitialImage);
+    const [previouseSelectedImage, setPreviousSelectedImage] = useState<any | null>(null);
     const [nextSelectedImage, setNextSelectedImage] = useState<any | null>(null);
     const [index, setIndex] = useState(0);
     const isDarkTheme = useSelector((state: RootState) => state.app.isDarkTheme);
@@ -78,4 +77,4 @@ const PhotoGallery = ({images, imageDescriptions}: PhotoGalleryProps) => {
     );
 };
 
-export default PhotoGallery;
+export default React.memo(PhotoGallery);

--- a/src/components/main-page/SelectedPhoto.tsx
+++ b/src/components/main-page/SelectedPhoto.tsx
@@ -31,7 +31,7 @@ const SelectedPhoto = ({
         setIndex(index - 1);
         setPreviousSelectedImage(images[index - 2]);
         setNextSelectedImage(images[index + 2]);
-        setSelectedImage(previouseSelectedImage?.default)
+        setSelectedImage(previouseSelectedImage?.src)
     }
 
     const handleNextClick = (e: any) => {
@@ -40,7 +40,7 @@ const SelectedPhoto = ({
         setIndex(index + 1);
         setPreviousSelectedImage(images[index - 2]);
         setNextSelectedImage(images[index + 2]);
-        setSelectedImage(nextSelectedImage?.default)
+        setSelectedImage(nextSelectedImage?.src)
     }
 
     const handleTouchStart = (e: any) => {

--- a/src/config/images.ts
+++ b/src/config/images.ts
@@ -1,14 +1,14 @@
 // config/images.ts
 
-// Use Vite’s import.meta.glob with eager loading so that each module is imported immediately.
-// This returns an object whose keys are the file paths and whose values are the module objects.
+// Use Vite's import.meta.glob to provide dynamic import functions for each image.
+// Each value is a function returning a promise that resolves to the module.
 export const images = Object.values(
-    import.meta.glob('../assets/photos/*.jpg', {eager: true})
-) as { default: string }[];
+    import.meta.glob('../assets/photos/*.jpg')
+) as Array<() => Promise<{ default: string }>>;
 
 export const canvaseImages = Object.values(
-    import.meta.glob('../assets/canvas/*.jpg', {eager: true})
-) as { default: string }[];
+    import.meta.glob('../assets/canvas/*.jpg')
+) as Array<() => Promise<{ default: string }>>;
 
 export const imageDescriptions = [
     {

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -10,7 +10,7 @@ const PhotographerDescriptionCard = React.lazy(() => import('../components/main-
 
 const MainPage = () => {
     const photos = useSelector((state: RootState) => state.app.photos);
-    const imageSources = photos?.map((photo: any) => photo.default);
+    const imageSources = photos?.map((photo: any) => photo.src);
 
     return (
         <div>


### PR DESCRIPTION
## Summary
- load gallery images on demand using dynamic imports
- update components to use new image objects
- drop unused placeholder import and memoize `PhotoGallery`
- add font preload hint

## Testing
- `npm test` *(fails: No test files found)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68545bfef164832b9161d56e43638f10